### PR TITLE
a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Installation
 To include in your gradle app:
 
 	dependencies {
-	  compile 'com.ykhdzr:flow::1.0.0'
+	  compile 'com.ykhdzr:flow:1.0.0'
 	}
 
 License


### PR DESCRIPTION
from
```gradle
dependencies {
  compile 'com.ykhdzr:flow::1.0.0'
}
```
to
```gradle
dependencies {
  compile 'com.ykhdzr:flow:1.0.0'
}
```